### PR TITLE
Cookie refactor

### DIFF
--- a/src/main/java/com/revature/services/AuthServiceImpl.java
+++ b/src/main/java/com/revature/services/AuthServiceImpl.java
@@ -6,14 +6,7 @@ import com.revature.models.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
-import java.util.Arrays;
 import java.util.Optional;
 
 @Service

--- a/src/test/java/com/revature/HashingTests.java
+++ b/src/test/java/com/revature/HashingTests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
 
 import javax.crypto.SecretKeyFactory;
@@ -77,7 +78,7 @@ public class HashingTests{
         LoginRequest request = new LoginRequest();
         request.setEmail("testuser@gmail.com");
         request.setPassword("password");
-        ResponseEntity<User> test = authController.login(request, new MockHttpSession());
+        ResponseEntity<User> test = authController.login(request, new MockHttpServletResponse());
         //Assertions.assertTrue(test.getStatusCodeValue() >= 200 && test.getStatusCodeValue() < 300);
     }
 
@@ -86,7 +87,7 @@ public class HashingTests{
         LoginRequest request = new LoginRequest();
         request.setEmail("testuser@gmail.com");
         request.setPassword("badPassword");
-        ResponseEntity<User> test = authController.login(request, new MockHttpSession());
+        ResponseEntity<User> test = authController.login(request, new MockHttpServletResponse());
         Assertions.assertFalse(test.getStatusCodeValue() >= 200 && test.getStatusCodeValue() < 300);
     }
 


### PR DESCRIPTION
We have removed sessions and replaced them with cookies, so now the pods are stateless!

Cookie security might be improved by obfuscating them with JWT (it currently stores the password in plaintext), but the access to this vulnerability is low, requiring a second vulnerability to be dangerous, such as the malicious person having access to the user's computer to view the password in the cookie, or using some other vulnerability in the website to steal the cookie to get the user's password.